### PR TITLE
feat: B站弹幕直接注入 AgentSession

### DIFF
--- a/chitose/config.py
+++ b/chitose/config.py
@@ -45,9 +45,11 @@ class DanmakuConfig:
     enabled: bool = False
     platform: str = "bilibili"
     room_id: int = 0
+    sessdata: str | None = None
     blocked_words: list[str] = field(default_factory=list)
     max_length: int = 100
     dedup_window: float = 5.0
+    sample_interval: float = 10.0
 
 
 @dataclass
@@ -117,9 +119,11 @@ class ChitoseConfig:
             config.danmaku.enabled = dm.get("enabled", config.danmaku.enabled)
             config.danmaku.platform = dm.get("platform", config.danmaku.platform)
             config.danmaku.room_id = dm.get("room_id", config.danmaku.room_id)
+            config.danmaku.sessdata = dm.get("sessdata", config.danmaku.sessdata)
             config.danmaku.blocked_words = dm.get("blocked_words", config.danmaku.blocked_words)
             config.danmaku.max_length = dm.get("max_length", config.danmaku.max_length)
             config.danmaku.dedup_window = dm.get("dedup_window", config.danmaku.dedup_window)
+            config.danmaku.sample_interval = dm.get("sample_interval", config.danmaku.sample_interval)
 
         return config
     
@@ -147,5 +151,9 @@ class ChitoseConfig:
             config.agent.tts_voice = voice
         if tts_model := os.getenv("ELEVENLABS_MODEL"):
             config.agent.tts_model = tts_model
-        
+
+        # Bilibili
+        if sessdata := os.getenv("BILI_SESSDATA"):
+            config.danmaku.sessdata = sessdata
+
         return config

--- a/chitose/config.py
+++ b/chitose/config.py
@@ -40,10 +40,22 @@ class AgentConfig:
 
 
 @dataclass
+class DanmakuConfig:
+    """Bilibili danmaku bridge configuration."""
+    enabled: bool = False
+    platform: str = "bilibili"
+    room_id: int = 0
+    blocked_words: list[str] = field(default_factory=list)
+    max_length: int = 100
+    dedup_window: float = 5.0
+
+
+@dataclass
 class ChitoseConfig:
     """Main configuration for Chitose."""
     livekit: LiveKitConfig = field(default_factory=LiveKitConfig)
     agent: AgentConfig = field(default_factory=AgentConfig)
+    danmaku: DanmakuConfig = field(default_factory=DanmakuConfig)
     
     @classmethod
     def load(cls, config_path: Optional[str] = None) -> "ChitoseConfig":
@@ -98,7 +110,17 @@ class ChitoseConfig:
             config.agent.tts_language = ag.get("tts_language", config.agent.tts_language)
             config.agent.system_prompt = ag.get("system_prompt", config.agent.system_prompt)
             config.agent.greeting = ag.get("greeting", config.agent.greeting)
-        
+
+        # Danmaku config
+        if "danmaku" in data:
+            dm = data["danmaku"]
+            config.danmaku.enabled = dm.get("enabled", config.danmaku.enabled)
+            config.danmaku.platform = dm.get("platform", config.danmaku.platform)
+            config.danmaku.room_id = dm.get("room_id", config.danmaku.room_id)
+            config.danmaku.blocked_words = dm.get("blocked_words", config.danmaku.blocked_words)
+            config.danmaku.max_length = dm.get("max_length", config.danmaku.max_length)
+            config.danmaku.dedup_window = dm.get("dedup_window", config.danmaku.dedup_window)
+
         return config
     
     @classmethod

--- a/chitose/danmaku/__init__.py
+++ b/chitose/danmaku/__init__.py
@@ -1,0 +1,6 @@
+"""Bilibili danmaku bridge for Chitose."""
+
+from chitose.danmaku.bridge import DanmakuBridge
+from chitose.danmaku.filter import DanmakuFilter
+
+__all__ = ["DanmakuBridge", "DanmakuFilter"]

--- a/chitose/danmaku/__init__.py
+++ b/chitose/danmaku/__init__.py
@@ -2,5 +2,6 @@
 
 from chitose.danmaku.bridge import DanmakuBridge
 from chitose.danmaku.filter import DanmakuFilter
+from chitose.danmaku.sampler import DanmakuSampler
 
-__all__ = ["DanmakuBridge", "DanmakuFilter"]
+__all__ = ["DanmakuBridge", "DanmakuFilter", "DanmakuSampler"]

--- a/chitose/danmaku/bridge.py
+++ b/chitose/danmaku/bridge.py
@@ -1,0 +1,116 @@
+"""DanmakuBridge: blivedm -> LiveKit room."""
+
+import logging
+
+import aiohttp
+import blivedm
+import blivedm.models.web as web_models
+from livekit import api, rtc
+
+from chitose.danmaku.filter import DanmakuFilter
+
+logger = logging.getLogger("chitose.danmaku")
+
+
+class DanmakuBridge:
+    """Read Bilibili danmaku and forward to a LiveKit room as text chat."""
+
+    def __init__(
+        self,
+        *,
+        room_id: int,
+        livekit_url: str,
+        livekit_api_key: str,
+        livekit_api_secret: str,
+        livekit_room_name: str,
+        danmaku_filter: DanmakuFilter,
+    ):
+        self._bili_room_id = room_id
+        self._lk_url = livekit_url
+        self._lk_api_key = livekit_api_key
+        self._lk_api_secret = livekit_api_secret
+        self._lk_room_name = livekit_room_name
+        self._filter = danmaku_filter
+
+        self._http_session: aiohttp.ClientSession | None = None
+        self._bli_client: blivedm.BLiveClient | None = None
+        self._lk_room: rtc.Room | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Connect to both Bilibili and LiveKit."""
+        # LiveKit: generate token and join as "danmaku-bridge"
+        token = (
+            api.AccessToken(self._lk_api_key, self._lk_api_secret)
+            .with_identity("danmaku-bridge")
+            .with_grants(api.VideoGrants(room_join=True, room=self._lk_room_name))
+            .to_jwt()
+        )
+        self._lk_room = rtc.Room()
+        await self._lk_room.connect(self._lk_url, token)
+        logger.info("Joined LiveKit room %s as danmaku-bridge", self._lk_room_name)
+
+        # Bilibili: start blivedm client
+        self._http_session = aiohttp.ClientSession()
+        self._bli_client = blivedm.BLiveClient(
+            self._bili_room_id, session=self._http_session
+        )
+        handler = _Handler(self)
+        self._bli_client.set_handler(handler)
+        self._bli_client.start()
+        logger.info("Listening to Bilibili room %d", self._bili_room_id)
+
+    async def stop(self) -> None:
+        """Disconnect from both services."""
+        if self._bli_client:
+            self._bli_client.stop()
+            await self._bli_client.join()
+            await self._bli_client.stop_and_close()
+        if self._http_session:
+            await self._http_session.close()
+        if self._lk_room:
+            await self._lk_room.disconnect()
+        logger.info("DanmakuBridge stopped")
+
+    # ------------------------------------------------------------------
+    # Internal: forward messages
+    # ------------------------------------------------------------------
+
+    async def _forward_danmaku(self, uname: str, msg: str) -> None:
+        if not self._filter.should_accept(uname, msg):
+            return
+        text = f"[{uname}] {msg}"
+        await self._lk_room.local_participant.send_text(text, topic="lk.chat")
+        logger.debug("Forwarded danmaku: %s", text)
+
+    async def _forward_super_chat(
+        self, uname: str, price: int, message: str
+    ) -> None:
+        if not self._filter.should_accept(uname, message):
+            return
+        text = f"[SC ¥{price} {uname}] {message}"
+        await self._lk_room.local_participant.send_text(text, topic="lk.chat")
+        logger.debug("Forwarded SC: %s", text)
+
+
+class _Handler(blivedm.BaseHandler):
+    """blivedm handler that delegates to DanmakuBridge."""
+
+    def __init__(self, bridge: DanmakuBridge):
+        super().__init__()
+        self._bridge = bridge
+
+    def _on_danmaku(
+        self, client: blivedm.BLiveClient, message: web_models.DanmakuMessage
+    ):
+        return self._bridge._forward_danmaku(message.uname, message.msg)
+
+    def _on_super_chat(
+        self, client: blivedm.BLiveClient, message: web_models.SuperChatMessage
+    ):
+        return self._bridge._forward_super_chat(
+            message.uname, message.price, message.message
+        )

--- a/chitose/danmaku/filter.py
+++ b/chitose/danmaku/filter.py
@@ -1,0 +1,48 @@
+"""Danmaku filtering: blocked words, length limit, dedup."""
+
+import time
+from dataclasses import dataclass, field
+
+
+@dataclass
+class DanmakuFilter:
+    """Filter danmaku messages by content rules."""
+
+    blocked_words: list[str] = field(default_factory=list)
+    max_length: int = 100
+    dedup_window: float = 5.0
+
+    def __post_init__(self):
+        # key: (username, content) -> timestamp
+        self._recent: dict[tuple[str, str], float] = {}
+
+    def should_accept(self, username: str, content: str) -> bool:
+        """Return True if the danmaku should be forwarded."""
+        # 长度检查
+        if len(content) > self.max_length:
+            return False
+
+        # 屏蔽词
+        content_lower = content.lower()
+        for word in self.blocked_words:
+            if word.lower() in content_lower:
+                return False
+
+        # 去重：同用户同内容在窗口内只保留一条
+        now = time.monotonic()
+        key = (username, content)
+        if key in self._recent and now - self._recent[key] < self.dedup_window:
+            return False
+        self._recent[key] = now
+
+        # 顺便清理过期条目
+        self._cleanup(now)
+        return True
+
+    def _cleanup(self, now: float) -> None:
+        expired = [
+            k for k, t in self._recent.items()
+            if now - t >= self.dedup_window
+        ]
+        for k in expired:
+            del self._recent[k]

--- a/chitose/danmaku/sampler.py
+++ b/chitose/danmaku/sampler.py
@@ -1,0 +1,52 @@
+"""DanmakuSampler: cooldown-based sampling for ordinary danmaku."""
+
+import asyncio
+import logging
+import random
+from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger("chitose.danmaku")
+
+
+class DanmakuSampler:
+    """Buffer ordinary danmaku and forward one random pick every *interval* seconds."""
+
+    def __init__(
+        self,
+        interval: float,
+        forward: Callable[[str], Awaitable[None]],
+    ):
+        self._interval = interval
+        self._forward = forward
+        self._buffer: list[str] = []
+        self._task: asyncio.Task | None = None
+
+    def submit(self, text: str) -> None:
+        """Non-blocking: add a danmaku to the buffer."""
+        self._buffer.append(text)
+
+    def start(self) -> None:
+        self._task = asyncio.create_task(self._drain_loop())
+
+    async def stop(self) -> None:
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _drain_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self._interval)
+            if not self._buffer:
+                continue
+            pick = random.choice(self._buffer)
+            dropped = len(self._buffer) - 1
+            self._buffer.clear()
+            try:
+                await self._forward(pick)
+                logger.debug("Sampled danmaku: %s (dropped %d)", pick, dropped)
+            except Exception:
+                logger.exception("Failed to forward sampled danmaku")

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -36,14 +36,18 @@ agent:
     - 尾音常常轻轻收掉，不太肯定的感觉
     - 禁止使用任何emoji
 
-  # greeting: "……啊，有人来了。我是千岁。"
-  greeting: "oh, someone is here. I'm Chitose."
+  greeting: "……啊，有人来了。我是千岁。"
+  # greeting: "oh, someone is here. I'm Chitose."
 
 # 弹幕桥接配置
 danmaku:
-  enabled: false
+  enabled: true
   platform: bilibili
-  room_id: 0             # B站直播间号
+  room_id: 999      # B站直播间号
+  # B站登录 cookie，不设则看不到完整用户名（显示为 "栖***" 这样的脱敏格式）
+  # 获取方式：浏览器登录 bilibili.com → F12 → Application → Cookies → 复制 SESSDATA 的值
+  sessdata: ${BILI_SESSDATA}
   blocked_words: []
   max_length: 100
   dedup_window: 5         # 秒，同用户同内容去重窗口
+  sample_interval: 10     # 秒，普通弹幕采样间隔，0=不限制

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -38,3 +38,12 @@ agent:
 
   # greeting: "……啊，有人来了。我是千岁。"
   greeting: "oh, someone is here. I'm Chitose."
+
+# 弹幕桥接配置
+danmaku:
+  enabled: false
+  platform: bilibili
+  room_id: 0             # B站直播间号
+  blocked_words: []
+  max_length: 100
+  dedup_window: 5         # 秒，同用户同内容去重窗口

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,138 @@
+# Chitose 系统架构
+
+> 基于 LiveKit Agents 的低延迟 AI VTuber 系统
+
+## 系统总览
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Chitose 系统                            │
+│                                                             │
+│  ┌──────────┐    ┌──────────────┐    ┌──────────────────┐   │
+│  │ 弹幕桥接  │───▶│              │    │   Web 前端        │   │
+│  │ (danmaku) │    │  LiveKit     │◀──▶│  Live2D + 口型    │   │
+│  └──────────┘    │  Server      │    │  同步 + 聊天      │   │
+│                  │              │    └──────────────────┘   │
+│  ┌──────────┐    │  (WebRTC     │                          │
+│  │ 语音输入  │───▶│   实时通信)   │    ┌──────────────────┐   │
+│  │ (STT/VAD)│    │              │───▶│   OBS / 直播推流   │   │
+│  └──────────┘    └──────┬───────┘    └──────────────────┘   │
+│                         │                                   │
+│                  ┌──────▼───────┐                           │
+│                  │ Agent Core   │                           │
+│                  │ (LLM + TTS)  │                           │
+│                  └──────────────┘                           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## 核心数据流
+
+```
+用户输入 ──▶ LiveKit Room ──▶ Agent ──▶ LLM 生成回复 ──▶ TTS 语音合成
+  │                                                          │
+  ├─ 语音 (WebRTC/STT)                                       │
+  ├─ 文字 (Web 聊天框)                                        ▼
+  └─ 弹幕 (B站 → Bridge)                          LiveKit Room ──▶ Web 前端
+                                                    │            │
+                                                    │            ├─ 音频播放
+                                                    │            └─ 口型同步
+                                                    ▼
+                                                  OBS 采集
+```
+
+三种输入通道最终都汇聚到同一个 LiveKit Room，Agent 统一处理后通过 TTS 输出语音。
+
+## 模块划分
+
+### 1. Agent Core (`chitose/agent.py`, `main.py`)
+
+系统核心。基于 LiveKit Agents 框架，负责：
+- 接收用户输入（语音 / 文字 / 弹幕）
+- 调用 LLM 生成回复
+- 通过 TTS 输出语音
+
+关键组件：
+- `ChitoseAgent(Agent)` — 人设定义、生命周期钩子
+- `entrypoint()` — 组装 STT / VAD / LLM / TTS pipeline，启动 session
+
+入口命令：`python main.py dev` 或 `python main.py connect`
+
+### 2. 配置系统 (`chitose/config.py`, `config/`)
+
+三层配置合并：dataclass 默认值 → YAML 文件 → 环境变量覆盖。
+
+```
+ChitoseConfig
+├── LiveKitConfig    — 服务器连接
+├── AgentConfig      — LLM / TTS / 人设
+└── DanmakuConfig    — 弹幕桥接开关与过滤规则
+```
+
+### 3. 弹幕桥接 (`chitose/danmaku/`)
+
+将 B 站直播弹幕转发到 LiveKit Room，让 Agent 能"看到"弹幕。
+
+```
+B站直播间 ──(blivedm)──▶ DanmakuFilter ──▶ DanmakuBridge ──▶ LiveKit Room
+                          │                  │
+                          ├─ 屏蔽词过滤       ├─ 以 "danmaku-bridge" 身份加入房间
+                          ├─ 长度限制         └─ 通过 lk.chat topic 发送文字
+                          └─ 同用户去重
+```
+
+### 4. Web 前端 (`web/`)
+
+纯静态页面，负责 Live2D 形象渲染和音频口型同步。
+
+技术栈：PixiJS 7 + pixi-live2d-display + LiveKit Client SDK
+
+功能：
+- Live2D 模型加载与渲染（透明背景，OBS 可抠像）
+- 接收 Agent 音频轨道，通过 Web Audio API 分析音量驱动口型
+- 聊天输入框，通过 `lk.chat` topic 发送文字给 Agent
+- 空格拖拽 + Ctrl 滚轮缩放
+
+## 技术栈
+
+| 层级 | 技术 | 用途 |
+|------|------|------|
+| 实时通信 | LiveKit (WebRTC) | 音视频传输、文字消息 |
+| Agent 框架 | LiveKit Agents | pipeline 编排、房间管理 |
+| LLM | OpenAI Compatible API | 对话生成 |
+| TTS | ElevenLabs | 语音合成 |
+| STT | Deepgram (multilingual) | 语音识别 |
+| VAD | Silero | 语音活动检测 |
+| 弹幕 | blivedm | B 站弹幕协议 |
+| 前端渲染 | PixiJS + pixi-live2d-display | Live2D 模型 |
+| 口型同步 | Web Audio API (频率分析) | 音量 → 嘴型映射 |
+
+## 目录结构
+
+```
+Chitose/
+├── main.py                  # 入口，组装 pipeline
+├── chitose/
+│   ├── agent.py             # Agent 定义（人设 + 钩子）
+│   ├── config.py            # 配置 dataclass + 加载逻辑
+│   ├── utils.py             # 日志、文本截断等工具
+│   └── danmaku/
+│       ├── bridge.py        # blivedm → LiveKit 转发
+│       └── filter.py        # 弹幕过滤（屏蔽词/去重/长度）
+├── web/
+│   ├── index.html           # Live2D 展示页
+│   ├── app.js               # 渲染 + LiveKit 音频 + 口型同步
+│   └── lib/                 # Cubism Core SDK
+├── config/
+│   └── default.yaml         # 默认配置模板
+└── docs/                    # 文档
+```
+
+## 扩展方向
+
+当前已实现 MVP 核心管道 + B 站弹幕桥接 + Live2D 口型同步。
+
+近期规划（详见 `docs/TODO.md`）：
+- 表情 / 动作系统 — LLM 输出情感标签驱动 Live2D 表情预设
+- 记忆系统 — hybrid search 跨会话记忆
+- 弹幕智能选择 — 过滤 + 优先级队列，挑最值得回的弹幕
+- SC / 礼物反应 — 监听礼物事件触发特殊回应

--- a/main.py
+++ b/main.py
@@ -92,6 +92,9 @@ async def entrypoint(ctx: JobContext):
     if config.danmaku.enabled and config.danmaku.room_id:
         from chitose.danmaku import DanmakuBridge, DanmakuFilter
 
+        async def _on_danmaku(text: str) -> None:
+            session.generate_reply(user_input=text)
+
         danmaku_filter = DanmakuFilter(
             blocked_words=config.danmaku.blocked_words,
             max_length=config.danmaku.max_length,
@@ -99,11 +102,10 @@ async def entrypoint(ctx: JobContext):
         )
         bridge = DanmakuBridge(
             room_id=config.danmaku.room_id,
-            livekit_url=config.livekit.url,
-            livekit_api_key=config.livekit.api_key,
-            livekit_api_secret=config.livekit.api_secret,
-            livekit_room_name=ctx.room.name,
+            on_danmaku=_on_danmaku,
             danmaku_filter=danmaku_filter,
+            sessdata=config.danmaku.sessdata,
+            sample_interval=config.danmaku.sample_interval,
         )
         await bridge.start()
         logger.info("Danmaku bridge started for Bilibili room %d", config.danmaku.room_id)

--- a/main.py
+++ b/main.py
@@ -88,6 +88,26 @@ async def entrypoint(ctx: JobContext):
         ),
     )
     
+    # 弹幕桥接
+    if config.danmaku.enabled and config.danmaku.room_id:
+        from chitose.danmaku import DanmakuBridge, DanmakuFilter
+
+        danmaku_filter = DanmakuFilter(
+            blocked_words=config.danmaku.blocked_words,
+            max_length=config.danmaku.max_length,
+            dedup_window=config.danmaku.dedup_window,
+        )
+        bridge = DanmakuBridge(
+            room_id=config.danmaku.room_id,
+            livekit_url=config.livekit.url,
+            livekit_api_key=config.livekit.api_key,
+            livekit_api_secret=config.livekit.api_secret,
+            livekit_room_name=ctx.room.name,
+            danmaku_filter=danmaku_filter,
+        )
+        await bridge.start()
+        logger.info("Danmaku bridge started for Bilibili room %d", config.danmaku.room_id)
+
     logger.info("Chitose agent is now active!")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,11 @@ dependencies = [
     "livekit-plugins-openai>=1.0.0",
     "livekit-plugins-elevenlabs>=1.0.0",
     "livekit-plugins-silero>=1.0.0",
+    "livekit-plugins-deepgram>=1.0.0",
+    "livekit-api>=1.0.0",
     "pyyaml>=6.0",
     "python-dotenv>=1.0.0",
+    "blivedm>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "livekit-api>=1.0.0",
     "pyyaml>=6.0",
     "python-dotenv>=1.0.0",
-    "blivedm>=2.0.0",
 ]
 
 [project.optional-dependencies]
@@ -29,6 +28,9 @@ dev = [
 
 [project.scripts]
 chitose = "chitose.main:main"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary
- DanmakuBridge 从 LiveKit participant 模式改为纯 B 站监听器 + 回调模式
- 弹幕通过 `session.generate_reply(user_input=...)` 直接注入 AgentSession，agent 像处理用户输入一样回复
- SC 绕过 sampler 立即转发，普通弹幕走 sampler 采样
- 新增 `DanmakuSampler`（cooldown-based 采样）、`DanmakuFilter`（屏蔽词/去重/长度限制）
- config 新增 `sessdata`、`sample_interval` 字段

## Test plan
- [x] 启动 agent + playground，B 站发弹幕 → agent 语音+文字回复
- [x] agent 说话时发弹幕 → 不打断，说完后回复
- [x] SC 弹幕 → 立即被回复
- [x] sampler 采样逻辑正常（高频弹幕被采样）